### PR TITLE
vmfex-upgrade: fix flake8 warnings

### DIFF
--- a/vmfex-upgrade-3.6-to-4.0.py
+++ b/vmfex-upgrade-3.6-to-4.0.py
@@ -28,12 +28,14 @@ from ovirtsdk.xml import params
 
 logging.basicConfig(level=logging.DEBUG, filename='vmfex-upgrade.log')
 
+
 def get_vmfex(vm):
     if vm.custom_properties:
         for custom_property in vm.custom_properties.custom_property:
             if custom_property.name == "vmfex":
                 return custom_property.value
     return None
+
 
 def get_profiles(vmfex):
     vmfex_dict = ast.literal_eval(vmfex)
@@ -44,10 +46,13 @@ def get_profiles(vmfex):
 
     return profile_name_to_id
 
+
 def add_profiles(vm, vmfex):
     for (profile_name, profile_id) in get_profiles(vmfex).items():
         try:
-            logging.info("Adding profile name: %s, id: %s", profile_name, profile_id)
+            logging.info(
+                "Adding profile name: %s, id: %s", profile_name, profile_id
+            )
             vm.nics.add(
                 params.NIC(
                     name=profile_name,
@@ -61,6 +66,7 @@ def add_profiles(vm, vmfex):
             # probably adding an existing vnic. Ignore this exception
             logging.exception(e)
 
+
 def move_vm_to_cluster(vm, cluster):
     logging.info("Moving the VM to cluster: %s", cluster)
     vm.cluster = params.Cluster(name=cluster)
@@ -68,7 +74,8 @@ def move_vm_to_cluster(vm, cluster):
         vm.update()
     except Exception as e:
         # getting exception that VM cannot be updated if some of the specified
-        # custom properties are not configured by the system. Ignoring this exception.
+        # custom properties are not configured by the system.
+        # Ignoring this exception.
         logging.exception(e)
 
 if __name__ == '__main__':
@@ -82,7 +89,9 @@ if __name__ == '__main__':
         exit()
 
     args = parser.parse_args()
-    password = getpass.getpass(prompt='Please enter RHV Manager admin password: ')
+    password = getpass.getpass(
+        prompt='Please enter RHV Manager admin password: '
+    )
 
     api = API(url=args.url, username=args.username, password=password)
 
@@ -93,7 +102,7 @@ if __name__ == '__main__':
         exit()
 
     vmfex = get_vmfex(vm)
-    if vmfex == None:
+    if vmfex is None:
         print("No vmfex property found. Exiting ...")
         logging.info("No vmfex property found. Exiting ...")
         exit()


### PR DESCRIPTION
$ flake8 vmfex-upgrade-3.6-to-4.0.py
vmfex-upgrade-3.6-to-4.0.py:31:1: E302 expected 2 blank lines, found 1
vmfex-upgrade-3.6-to-4.0.py:38:1: E302 expected 2 blank lines, found 1
vmfex-upgrade-3.6-to-4.0.py:47:1: E302 expected 2 blank lines, found 1
vmfex-upgrade-3.6-to-4.0.py:50:80: E501 line too long (85 > 79 characters)
vmfex-upgrade-3.6-to-4.0.py:64:1: E302 expected 2 blank lines, found 1
vmfex-upgrade-3.6-to-4.0.py:71:80: E501 line too long (86 > 79 characters)
vmfex-upgrade-3.6-to-4.0.py:85:80: E501 line too long (82 > 79 characters)
vmfex-upgrade-3.6-to-4.0.py:96:14: E711 comparison to None should be 'if cond is None:'